### PR TITLE
Cross build to 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,9 @@ branches:
 before_install:
   - curl https://raw.githubusercontent.com/scala-native/scala-native/v0.3.7/scripts/travis_setup.sh | bash -x
 install:
-  - pyenv install -s 3.6.3
-  - pyenv global 3.6.3
-  - pip install jep
+  - pyenv install -s 3.7.1
+  - pyenv global 3.7.1
 script:
-  - export JEP_PATH="/opt/python/3.6.3/lib/python3.6/site-packages/jep"
   - export LD_LIBRARY_PATH=$(python3-config --prefix)/lib
   - pip install numpy
   - sbt test

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,14 @@
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
+import scala.sys.process._
 
 organization in ThisBuild := "me.shadaj"
 
-scalaVersion in ThisBuild := "2.12.8"
+lazy val scala211Version = "2.11.12"
+lazy val scala212Version = "2.12.8"
+lazy val scala213Version = "2.13.1"
+lazy val supportedScalaVersions = List(scala212Version, scala213Version)
+
+scalaVersion in ThisBuild := scala213Version
 
 addCommandAlias(
   "publishSignedAll",
@@ -27,14 +33,16 @@ lazy val scalaPyNumpyCross = crossProject(JVMPlatform, NativePlatform)
   .in(file("."))
   .settings(
     name := "scalapy-numpy",
-    libraryDependencies += "me.shadaj" %%% "scalapy-core" % "0.3.0",
-    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0-SNAP8" % Test
+    libraryDependencies += "me.shadaj" %%% "scalapy-core" % "0.3.0+15-598682f0",
   ).jvmSettings(
+    crossScalaVersions := supportedScalaVersions,
+    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0" % Test,
     libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.0" % Test,
     fork in Test := true,
-    javaOptions in Test += s"-Djava.library.path=${sys.env.getOrElse("JEP_PATH", "/usr/local/lib/python3.7/site-packages/jep")}"
+    javaOptions in Test += s"-Djna.library.path=${"python3-config --prefix".!!.trim}/lib"
   ).nativeSettings(
     scalaVersion := "2.11.12",
+    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0-SNAP8" % Test,
     libraryDependencies += "com.github.lolgab" %%% "scalacheck" % "1.14.1" % Test,
     nativeLinkStubs := true,
     nativeLinkingOptions ++= {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.3.8")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
 
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")

--- a/publish.sbt
+++ b/publish.sbt
@@ -4,7 +4,7 @@ pomIncludeRepository in ThisBuild := { _ => false }
 
 publishArtifact in Test in ThisBuild := false
 
-publishTo in ThisBuild := Some(Opts.resolver.sonatypeStaging)
+publishTo in ThisBuild := sonatypePublishToBundle.value
 
 pomExtra in ThisBuild :=
   <url>https://github.com/shadaj/scalapy-numpy</url>

--- a/publish.sh
+++ b/publish.sh
@@ -6,4 +6,4 @@ openssl aes-256-cbc -K $encrypted_e61d3e3c6cc6_key -iv $encrypted_e61d3e3c6cc6_i
 
 tar xvf secrets.tar
 
-sbt publishSigned sonatypeRelease
+sbt +publishSigned sonatypeRelease

--- a/publish.sh
+++ b/publish.sh
@@ -6,4 +6,4 @@ openssl aes-256-cbc -K $encrypted_e61d3e3c6cc6_key -iv $encrypted_e61d3e3c6cc6_i
 
 tar xvf secrets.tar
 
-sbt +publishSigned sonatypeRelease
+sbt publishSignedAll sonatypeBundleRelease

--- a/src/main/scala/me/shadaj/scalapy/numpy/NDArray.scala
+++ b/src/main/scala/me/shadaj/scalapy/numpy/NDArray.scala
@@ -1,7 +1,7 @@
 package me.shadaj.scalapy.numpy
 
 import me.shadaj.scalapy.py
-import me.shadaj.scalapy.py.{PyValue, Reader, Writer, ValueAndRequestRef}
+import me.shadaj.scalapy.py.{PyValue, Reader, Writer}
 
 class NDArray[T](val value: PyValue)(implicit reader: Reader[T]) extends py.Object with Seq[T] {
   private val origDynamic = this.as[py.Dynamic]
@@ -35,6 +35,6 @@ class NDArray[T](val value: PyValue)(implicit reader: Reader[T]) extends py.Obje
 
 object NDArray {
   implicit def reader[T](implicit reader: Reader[T]): Reader[NDArray[T]] = new Reader[NDArray[T]] {
-    override def read(r: ValueAndRequestRef): NDArray[T] = new NDArray[T](r.value)(reader)
+    override def read(v: PyValue): NDArray[T] = new NDArray[T](v)(reader)
   }
 }


### PR DESCRIPTION
This PR adds cross-building to Scala 2.13, similarly to shadaj/scalapy#46. 

It also tries to make publishing to Sonatype work, similarly to shadaj/scalapy@25419b3fa9de54c03b409e11f71be006292c298b and shadaj/scalapy@598682f00466e4fb035ee32d76af17935d855418.